### PR TITLE
Update example in readme for schema update

### DIFF
--- a/pointstore_api.md
+++ b/pointstore_api.md
@@ -134,8 +134,8 @@ curl -X POST https://q81rej0j12.execute-api.us-east-1.amazonaws.com/order \
   "bbox": "5,60,6,61",
   "datasets": [
     {
-      "type": "csb",
-      "platform": "Ramform Vanguard"
+      "label": "csb",
+      "platforms": ["Ramform Vanguard"]
     }
   ]
 }'


### PR DESCRIPTION
The example from the docs is failing with the newest schema changes: 
```curl

curl -X POST https://q81rej0j12.execute-api.us-east-1.amazonaws.com/order \
   -H 'Content-Type: application/json' \
   -d '{
  "email": "your.email.address@example.com",
  "bbox": "5,60,6,61",
  "datasets": [
    {
      "type": "csb",
      "platform": "Ramform Vanguard"
    }
  ]
}'
```
This works (label and platform --> platforms (and it's an array): 
```curl

curl -X POST https://q81rej0j12.execute-api.us-east-1.amazonaws.com/order \
   -H 'Content-Type: application/json' \
   -d '{
  "email": "your.email.address@example.com",
  "bbox": "5,60,6,61",
  "datasets": [
    {
      "label": "csb",
      "platforms": ["Ramform Vanguard"]
    }
  ]
}'
```

